### PR TITLE
Updating names of resources

### DIFF
--- a/modules/keyvault.bicep
+++ b/modules/keyvault.bicep
@@ -26,7 +26,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   properties: {
     enabledForDeployment: enableVaultForDeployment
     enableRbacAuthorization: true
-    enableSoftDelete: true
+    enableSoftDelete: false
     enabledForTemplateDeployment: true
     sku: {
       family: 'A'

--- a/parameters/dev.parameters.json
+++ b/parameters/dev.parameters.json
@@ -6,40 +6,40 @@
             "value": "nonprod"
         },
         "postgresSQLServerName": {
-            "value": "aswin-dbsrv-dev"
+            "value": "404moneynotfound-dbsrv-dev"
         },
         "postgresSQLDatabaseName": {
-            "value": "aswin-db-dev"
+            "value": "404moneynotfound-db-dev"
         },
         "appServicePlanName": {
-            "value": "aswin-asp-dev"
+            "value": "404moneynotfound-asp-dev"
         },
         "appServiceAPIAppName": {
-            "value": "aswin-be-dev"
+            "value": "404moneynotfound-be-dev"
         },
         "appServiceAppName": {
-            "value": "aswin-fe-dev"
+            "value": "404moneynotfound-fe-dev"
         },
         "location": {
             "value": "North Europe"
         },
         "containerRegistryName": {
-            "value": "aswinacrdev"
+            "value": "404moneynotfoundacrdev"
         },
         "dockerRegistryImageName": {
-            "value": "aswin-be-dev"
+            "value": "404moneynotfound-be-dev"
         },
         "dockerRegistryImageTag": {
             "value": "latest"
         },
         "logAnalyticsWorkspaceName": {
-            "value": "diana-logAnalyticsWorkspace-dev" 
+            "value": "404moneynotfound-logAnalyticsWorkspace-dev"
         },
         "appInsightsName": {
-            "value": "diana-appInsights-dev"
-        }, 
+            "value": "404moneynotfound-appInsights-dev"
+        },
         "keyVaultName": {
-            "value": "aswin-kv-dev"
+            "value": "404moneynotfound-kv-dev"
         },
         "keyVaultRoleAssignments": {
             "value": [

--- a/parameters/dev.parameters.json
+++ b/parameters/dev.parameters.json
@@ -6,40 +6,40 @@
             "value": "nonprod"
         },
         "postgresSQLServerName": {
-            "value": "404moneynotfound-dbsrv-dev"
+            "value": "404money-dbsrv-dev"
         },
         "postgresSQLDatabaseName": {
-            "value": "404moneynotfound-db-dev"
+            "value": "404money-db-dev"
         },
         "appServicePlanName": {
-            "value": "404moneynotfound-asp-dev"
+            "value": "404money-asp-dev"
         },
         "appServiceAPIAppName": {
-            "value": "404moneynotfound-be-dev"
+            "value": "404money-be-dev"
         },
         "appServiceAppName": {
-            "value": "404moneynotfound-fe-dev"
+            "value": "404money-fe-dev"
         },
         "location": {
             "value": "North Europe"
         },
         "containerRegistryName": {
-            "value": "404moneynotfoundacrdev"
+            "value": "404moneyacrdev"
         },
         "dockerRegistryImageName": {
-            "value": "404moneynotfound-be-dev"
+            "value": "404money-be-dev"
         },
         "dockerRegistryImageTag": {
             "value": "latest"
         },
         "logAnalyticsWorkspaceName": {
-            "value": "404moneynotfound-logAnalyticsWorkspace-dev"
+            "value": "404money-law-dev"
         },
         "appInsightsName": {
-            "value": "404moneynotfound-appInsights-dev"
+            "value": "404money-appInsights-dev"
         },
         "keyVaultName": {
-            "value": "404moneynotfound-kv-dev"
+            "value": "404money-kv-dev"
         },
         "keyVaultRoleAssignments": {
             "value": [

--- a/parameters/dev.parameters.json
+++ b/parameters/dev.parameters.json
@@ -6,40 +6,40 @@
             "value": "nonprod"
         },
         "postgresSQLServerName": {
-            "value": "404money-dbsrv-dev"
+            "value": "money404-dbsrv-dev"
         },
         "postgresSQLDatabaseName": {
-            "value": "404money-db-dev"
+            "value": "money404-db-dev"
         },
         "appServicePlanName": {
-            "value": "404money-asp-dev"
+            "value": "money404-asp-dev"
         },
         "appServiceAPIAppName": {
-            "value": "404money-be-dev"
+            "value": "money404-be-dev"
         },
         "appServiceAppName": {
-            "value": "404money-fe-dev"
+            "value": "money404-fe-dev"
         },
         "location": {
             "value": "North Europe"
         },
         "containerRegistryName": {
-            "value": "404moneyacrdev"
+            "value": "money404acrdev"
         },
         "dockerRegistryImageName": {
-            "value": "404money-be-dev"
+            "value": "money404-be-dev"
         },
         "dockerRegistryImageTag": {
             "value": "latest"
         },
         "logAnalyticsWorkspaceName": {
-            "value": "404money-law-dev"
+            "value": "money404-law-dev"
         },
         "appInsightsName": {
-            "value": "404money-appInsights-dev"
+            "value": "money404-appInsights-dev"
         },
         "keyVaultName": {
-            "value": "404money-kv-dev"
+            "value": "money404-kv-dev"
         },
         "keyVaultRoleAssignments": {
             "value": [

--- a/parameters/uat.parameters.json
+++ b/parameters/uat.parameters.json
@@ -6,40 +6,40 @@
           "value": "nonprod"
       },
       "postgresSQLServerName": {
-          "value": "aswin-dbsrv-uat"
+          "value": "404moneynotfound-dbsrv-uat"
       },
       "postgresSQLDatabaseName": {
-          "value": "aswin-db-uat"
+          "value": "404moneynotfound-db-uat"
       },
       "appServicePlanName": {
-          "value": "aswin-asp-uat"
+          "value": "404moneynotfound-asp-uat"
       },
       "appServiceAPIAppName": {
-          "value": "aswin-be-uat"
+          "value": "404moneynotfound-be-uat"
       },
       "appServiceAppName": {
-          "value": "aswin-fe-uat"
+          "value": "404moneynotfound-fe-uat"
       },
       "location": {
           "value": "North Europe"
       },
       "containerRegistryName": {
-        "value": "aswinacruat"
+        "value": "404moneynotfoundacruat"
       },
       "dockerRegistryImageName": {
-        "value": "aswin-be-uat"
+        "value": "404moneynotfound-be-uat"
       },
       "dockerRegistryImageTag": {
         "value": "latest"
       },
       "logAnalyticsWorkspaceName": {
-        "value": "diana-logAnalyticsWorkspace-uat" 
+        "value": "404moneynotfound-logAnalyticsWorkspace-uat"
       },
       "appInsightsName": {
-        "value": "diana-appInsights-uat"
+        "value": "404moneynotfound-appInsights-uat"
       },
         "keyVaultName": {
-            "value": "aswin-kv-uat"
+            "value": "404moneynotfound-kv-uat"
       },
         "keyVaultRoleAssignments": {
             "value": [

--- a/parameters/uat.parameters.json
+++ b/parameters/uat.parameters.json
@@ -6,40 +6,40 @@
           "value": "nonprod"
       },
       "postgresSQLServerName": {
-          "value": "404money-dbsrv-uat"
+          "value": "money404-dbsrv-uat"
       },
       "postgresSQLDatabaseName": {
-          "value": "404money-db-uat"
+          "value": "money404-db-uat"
       },
       "appServicePlanName": {
-          "value": "404money-asp-uat"
+          "value": "money404-asp-uat"
       },
       "appServiceAPIAppName": {
-          "value": "404money-be-uat"
+          "value": "money404-be-uat"
       },
       "appServiceAppName": {
-          "value": "404money-fe-uat"
+          "value": "money404-fe-uat"
       },
       "location": {
           "value": "North Europe"
       },
       "containerRegistryName": {
-        "value": "404moneyacruat"
+        "value": "money404acruat"
       },
       "dockerRegistryImageName": {
-        "value": "404money-be-uat"
+        "value": "money404-be-uat"
       },
       "dockerRegistryImageTag": {
         "value": "latest"
       },
       "logAnalyticsWorkspaceName": {
-        "value": "404money-law-uat"
+        "value": "money404-law-uat"
       },
       "appInsightsName": {
-        "value": "404money-appInsights-uat"
+        "value": "money404-appInsights-uat"
       },
         "keyVaultName": {
-            "value": "404money-kv-uat"
+            "value": "money404-kv-uat"
       },
         "keyVaultRoleAssignments": {
             "value": [

--- a/parameters/uat.parameters.json
+++ b/parameters/uat.parameters.json
@@ -6,40 +6,40 @@
           "value": "nonprod"
       },
       "postgresSQLServerName": {
-          "value": "404moneynotfound-dbsrv-uat"
+          "value": "404money-dbsrv-uat"
       },
       "postgresSQLDatabaseName": {
-          "value": "404moneynotfound-db-uat"
+          "value": "404money-db-uat"
       },
       "appServicePlanName": {
-          "value": "404moneynotfound-asp-uat"
+          "value": "404money-asp-uat"
       },
       "appServiceAPIAppName": {
-          "value": "404moneynotfound-be-uat"
+          "value": "404money-be-uat"
       },
       "appServiceAppName": {
-          "value": "404moneynotfound-fe-uat"
+          "value": "404money-fe-uat"
       },
       "location": {
           "value": "North Europe"
       },
       "containerRegistryName": {
-        "value": "404moneynotfoundacruat"
+        "value": "404moneyacruat"
       },
       "dockerRegistryImageName": {
-        "value": "404moneynotfound-be-uat"
+        "value": "404money-be-uat"
       },
       "dockerRegistryImageTag": {
         "value": "latest"
       },
       "logAnalyticsWorkspaceName": {
-        "value": "404moneynotfound-logAnalyticsWorkspace-uat"
+        "value": "404money-law-uat"
       },
       "appInsightsName": {
-        "value": "404moneynotfound-appInsights-uat"
+        "value": "404money-appInsights-uat"
       },
         "keyVaultName": {
-            "value": "404moneynotfound-kv-uat"
+            "value": "404money-kv-uat"
       },
         "keyVaultRoleAssignments": {
             "value": [


### PR DESCRIPTION
This pull request includes changes to the `parameters/dev.parameters.json` and `parameters/uat.parameters.json` files to update the naming conventions of various resources. The most important changes include updating the names of the PostgreSQL server, database, app service plan, app service API app, and app service app.

Changes to `parameters/dev.parameters.json`:

* Updated `postgresSQLServerName` value to "404moneynotfound-dbsrv-dev"
* Updated `postgresSQLDatabaseName` value to "404moneynotfound-db-dev"
* Updated `appServicePlanName` value to "404moneynotfound-asp-dev"
* Updated `appServiceAPIAppName` value to "404moneynotfound-be-dev"
* Updated `appServiceAppName` value to "404moneynotfound-fe-dev"

Changes to `parameters/uat.parameters.json`:

* Updated `postgresSQLServerName` value to "404moneynotfound-dbsrv-uat"
* Updated `postgresSQLDatabaseName` value to "404moneynotfound-db-uat"
* Updated `appServicePlanName` value to "404moneynotfound-asp-uat"
* Updated `appServiceAPIAppName` value to "404moneynotfound-be-uat"
* Updated `appServiceAppName` value to "404moneynotfound-fe-uat"