### PR TITLE
Drosel Added Correct key for logins

### DIFF
--- a/modules/infrastructure/keyvault.bicep
+++ b/modules/infrastructure/keyvault.bicep
@@ -11,7 +11,7 @@ output keyVaultUri string = keyVault.properties.vaultUri
 
 var builtInRoleNames = {
     'Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-    'Key Vault Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'daa3436a-d1fb-44fe-b34b-053db433cdb7')
+    'Key Vault Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
     'Key Vault Certificates Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')
     'Key Vault Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')
     'Key Vault Crypto Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','14b46e9e-c2b7-41b4-b07b-48a6ebf60603')

--- a/modules/infrastructure/keyvault.bicep
+++ b/modules/infrastructure/keyvault.bicep
@@ -11,7 +11,7 @@ output keyVaultUri string = keyVault.properties.vaultUri
 
 var builtInRoleNames = {
     'Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-    'Key Vault Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+    'Key Vault Administrator': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'daa3436a-d1fb-44fe-b34b-053db433cdb7')
     'Key Vault Certificates Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')
     'Key Vault Contributor': subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')
     'Key Vault Crypto Officer': subscriptionResourceId('Microsoft.Authorization/roleDefinitions','14b46e9e-c2b7-41b4-b07b-48a6ebf60603')

--- a/parameters/dev.parameters.json
+++ b/parameters/dev.parameters.json
@@ -44,9 +44,14 @@
     "keyVaultRoleAssignments": {
       "value": [
         {
-          "principalId": "daa3436a-d1fb-44fe-b34b-053db433cdb7",
-          "roleDefinitionIdOrName": "Key Vault Administrator",
-          "principalType": "Group"
+            "principalId": "daa3436a-d1fb-44fe-b34b-053db433cdb7",
+            "roleDefinitionIdOrName": "Key Vault Administrator",
+            "principalType": "Group"
+        },
+        {
+            "principalId": "37841ca3-42b3-4aed-b215-44d6f5dcb57d",
+            "roleDefinitionIdOrName": "Key Vault Secrets User",
+            "principalType": "ServicePrincipal"
         }
       ]
     },

--- a/parameters/dev.parameters.json
+++ b/parameters/dev.parameters.json
@@ -44,7 +44,7 @@
     "keyVaultRoleAssignments": {
       "value": [
         {
-          "principalId": "c52bb0cc-7f22-4c28-aee8-264d1cafbb06",
+          "principalId": "daa3436a-d1fb-44fe-b34b-053db433cdb7",
           "roleDefinitionIdOrName": "Key Vault Administrator",
           "principalType": "Group"
         }

--- a/parameters/dev.parameters.json
+++ b/parameters/dev.parameters.json
@@ -44,7 +44,7 @@
     "keyVaultRoleAssignments": {
       "value": [
         {
-          "principalId": "daa3436a-d1fb-44fe-b34b-053db433cdb7",
+          "principalId": "c52bb0cc-7f22-4c28-aee8-264d1cafbb06",
           "roleDefinitionIdOrName": "Key Vault Administrator",
           "principalType": "Group"
         }


### PR DESCRIPTION
This pull request includes a small change to the `parameters/dev.parameters.json` file. The change adds a new principal with the role of "Key Vault Secrets User" and the type "ServicePrincipal".

* [`parameters/dev.parameters.json`](diffhunk://#diff-9e3b5d8289fd9a257411bc4c842c1c6ab7700ce9c7e19118447bf8753e9f6c64R50-R54): Added a new principal with `principalId` "37841ca3-42b3-4aed-b215-44d6f5dcb57d", `roleDefinitionIdOrName` "Key Vault Secrets User", and `principalType` "ServicePrincipal".