### PR TITLE
Update main.workbook - Diana

### DIFF
--- a/workbooks/main.workbook
+++ b/workbooks/main.workbook
@@ -210,6 +210,7 @@
         "resourceType": "microsoft.insights/components",
         "metricScope": 0,
         "resourceIds": [
+          "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-PROD/providers/Microsoft.Insights/components/money404-appInsights-prod",
           "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourcegroups/bcsai2024-devops-students-b-dev/providers/microsoft.insights/components/money404-appinsights-dev"
         ],
         "timeContext": {
@@ -349,6 +350,7 @@
         "resourceType": "microsoft.keyvault/vaults",
         "metricScope": 0,
         "resourceIds": [
+          "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-PROD/providers/Microsoft.KeyVault/vaults/money404-kv-prod",
           "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-UAT/providers/Microsoft.KeyVault/vaults/money404-kv-uat"
         ],
         "timeContext": {
@@ -384,6 +386,7 @@
         "resourceType": "microsoft.dbforpostgresql/flexibleservers",
         "metricScope": 0,
         "resourceIds": [
+          "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-PROD/providers/Microsoft.DBforPostgreSQL/flexibleServers/money404-dbsrv-prod",
           "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-UAT/providers/Microsoft.DBforPostgreSQL/flexibleServers/money404-dbsrv-uat"
         ],
         "timeContext": {
@@ -393,8 +396,7 @@
           {
             "namespace": "microsoft.dbforpostgresql/flexibleservers",
             "metric": "microsoft.dbforpostgresql/flexibleservers-Availability-is_db_alive",
-            "aggregation": 3,
-            "splitBy": null
+            "aggregation": 3
           }
         ],
         "gridSettings": {
@@ -405,7 +407,7 @@
     }
   ],
   "fallbackResourceIds": [
-    "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-DEV/providers/Microsoft.Insights/components/money404-appInsights-dev"
+    "/subscriptions/e0b9cada-61bc-4b5a-bd7a-52c606726b3b/resourceGroups/BCSAI2024-DEVOPS-STUDENTS-B-PROD/providers/Microsoft.Insights/components/money404-appInsights-prod"
   ],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }


### PR DESCRIPTION
This pull request includes several updates to the `workbooks/main.workbook` file, primarily focusing on adding new production resources and modifying existing configurations.

Updates to production resources:

* Added a new production Application Insights resource ID to the `resourceIds` list.
* Added a new production Key Vault resource ID to the `resourceIds` list.
* Added a new production PostgreSQL flexible server resource ID to the `resourceIds` list.
* Updated the fallback resource ID to use the production Application Insights resource instead of the development one.

Configuration adjustments:

* Removed the `splitBy` property from the PostgreSQL flexible server metric configuration.